### PR TITLE
Remove `in(x, line)` for 2D version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeometricObjects"
 uuid = "f167b195-1c3d-409a-8dd6-02cc02a656c6"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/src/Line.jl
+++ b/src/Line.jl
@@ -114,22 +114,7 @@ false
 """
 function Base.in(x::Vec, line::AbstractLine)
     d, scale = _distance(line, x)
-    0 ≤ scale ≤ 1 && (d ⋅ d) < eps(eltype(d))
-end
-# much faster for 2D
-function Base.in(X::Vec{2}, line::AbstractLine{2})
-    @inbounds begin
-        x, y = X[1], X[2]
-        a, b = line
-        a_x, a_y = a[1], a[2]
-        b_x, b_y = b[1], b[2]
-    end
-    if (a_x ≤ x ≤ b_x) || (b_x ≤ x ≤ a_x)
-        if (a_y ≤ y ≤ b_y) || (b_y ≤ y ≤ a_y)
-            (x - a_x) * (b_y - a_y) == (y - a_y) * (b_x - a_x) && return true
-        end
-    end
-    false
+    0 ≤ scale ≤ 1 && (d ⋅ d) < sqrt(eps(eltype(d)))
 end
 
 # helper function for `in(x, polygon)`


### PR DESCRIPTION
2D version doesn't work well when `line` is almost vertical or horizontal.